### PR TITLE
ci: add support for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.2
+  codecov: codecov/codecov@3.0.0
+  commitlint: conventional-changelog/commitlint@1.0.0
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  cyclomatic-complexity:
+    docker:
+      - image: cimg/python:3.9
+    steps:
+      - checkout
+      - run:
+          name: install radon
+          command: pip install radon
+      - run:
+          name: run radon
+          command: |
+            radon cc -s -nb .
+            result=$(radon cc -s -nb .)
+            if [[ $? != 0 ]]; then
+                echo "Command failed."
+                exit 1
+            elif [[ $result ]]; then
+                echo "failed."
+                exit 1
+            else
+                echo "success."
+            fi  
+  flake8:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: install flake8
+          command: pip install flake8
+      - run:
+          name: run flake8
+          command: flake8 .
+  coverage: # This is the name of the job, feel free to change it to better match what you're trying to do!
+    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
+    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
+    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
+    # The executor is the environment in which the steps below will be executed - below will use a python 3.8 container
+    # Change the version below to your required version of python
+    docker:
+      - image: cimg/python:3.8
+    # Checkout the code as the first step. This is a dedicated CircleCI step.
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - run:
+          name: Setup testing environment
+          command: |
+            pip install coverage
+      - run:
+          name: Run Tests
+          command: |
+            coverage run -m unittest discover
+            coverage report
+            coverage html  # open htmlcov/index.html in a browser
+            coverage xml
+      - store_artifacts:
+          path: htmlcov
+      - codecov/upload
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - commitlint/lint:
+          target-branch: master
+      - flake8
+      - coverage
+      - cyclomatic-complexity

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Alohomora](https://circleci.com/gh/xiaomi388/comsw-4156-project/tree/master.svg?style=svg)](https://app.circleci.com/pipelines/github/xiaomi388/comsw-4156-project)
+[![codecov](https://codecov.io/gh/xiaomi388/comsw-4156-project/branch/master/graph/badge.svg?token=W6R9U4E57A)](https://codecov.io/gh/xiaomi388/comsw-4156-project)
+
 Course project for comsw4156
 
 Team Name: Alohomora

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+def foo(a, b):
+    return a+b
+
+
+if __name__ == "__main__":
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+coverage
+

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,7 @@
+import unittest
+import main
+
+
+class TestFoo(unittest.TestCase):
+    def test_normal(self):
+        self.assertEqual(main.foo(10, 20), 30)


### PR DESCRIPTION
This commit adds support for continuous integration.

Adds flake8 checker, cyclomatic complexity checker, coverage tester, and commit linter.