### PR TITLE
feat: add support for rating owner

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,5 +55,11 @@ def get_profile():
     return res
 
 
+@app.route("/furnitures/<fid>/rate", methods=["POST"])
+def post_rate(fid):
+    rating = request.args.get('rating', type=int)
+    return furniture.rate_owner(fid, user_email, rating)
+
+
 if __name__ == '__main__':
     app.run(debug=True, host='127.0.0.1')

--- a/db.py
+++ b/db.py
@@ -19,12 +19,14 @@ def init_db():
         create_furniture_query = """CREATE TABLE IF NOT EXISTS Furniture (
             fid INTEGER PRIMARY KEY AUTOINCREMENT,
             owner VARCHAR(20) NOT NULL,
+            buyer VARCHAR(20),
             title VARCHAR(50),
             labels TEXT,
             status TEXT NOT NULL DEFAULT "init",
             image_url TEXT,
             description VARCHAR(200),
-            FOREIGN KEY(owner) REFERENCES User(email)
+            FOREIGN KEY(owner) REFERENCES User(email),
+            FOREIGN KEY(buyer) REFERENCES User(email)
         );"""
         create_transaction_query = """CREATE TABLE IF NOT EXISTS Transactions (
             tid INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/furniture.py
+++ b/furniture.py
@@ -47,3 +47,46 @@ def create_furniture(furniture, owner):
         if conn:
             conn.close()
     return json.dumps({"error": ""}), 201
+
+
+def rate_owner(fid, buyer_email, rating):
+    if not (0 <= rating <= 5):
+        return json.dumps(
+            {"error": "rating score should be in the range of [0, 5]"}), 400
+    conn = None
+    try:
+        conn = sqlite3.connect("sqlite_db")
+        record = conn.execute(
+            "SELECT buyer, owner, status FROM Furniture WHERE fid = ?",
+            [fid]
+        ).fetchone()
+        if record is None:
+            return json.dumps({"error": "fid not existed"}), 400
+        real_buyer_email, owner, status = record
+        if buyer_email != real_buyer_email:
+            return json.dumps(
+                {"error": "rating can only be triggered by the buyer"}), 400
+        if status == "rated":
+            return json.dumps(
+                {"error": "this transaction has been rated"}), 400
+        if status != "completed":
+            return json.dumps(
+                {"error": "please rate after the transaction is completed"}
+            ), 400
+        conn.execute(
+            "UPDATE user SET transaction_count = "
+            "transaction_count+1, rating = rating+?"
+            "WHERE email = ?",
+            [rating, owner]
+        )
+        conn.execute(
+            "UPDATE furniture SET status = 'rated' WHERE fid=?",
+            [fid]
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        return json.dumps({"error": f"db error: {str(e)}"}), 500
+    finally:
+        if conn:
+            conn.close()
+    return json.dumps({"error": ""}), 200

--- a/search.py
+++ b/search.py
@@ -16,8 +16,9 @@ def search_furniture(keyword):
             return json.dumps({"error": "no matched furniture found"}), 201
         furniture_list = []
         for f in search_label_res:
-            fid, owner, title, labels, status, image_url, description = f
-            furniture_list.append({"fid": fid, "owner": owner,
+            fid, owner, buyer, title, \
+                labels, status, image_url, description = f
+            furniture_list.append({"fid": fid, "owner": owner, "buyer": buyer,
                                    "title": title, "labels": labels,
                                    "status": status, "image_url": image_url,
                                    "description": description})

--- a/test_furniture.py
+++ b/test_furniture.py
@@ -71,3 +71,105 @@ class TestFurniture(unittest.TestCase):
 
         self.assertEqual(code, 500)
         self.assertEqual(ret, json.dumps({"error": "db error: mockerr"}))
+
+    @patch('sqlite3.connect')
+    def test_rate_buyer_happy_path(self, mock):
+        class MockCursor:
+            @staticmethod
+            def fetchone():
+                return ["realbuyer@gmail.com", "owner@gmail.com", "completed"]
+
+        class MockConn:
+            def __init__(self):
+                self.exec_cnt = 0
+                self.params = []
+                self.has_commit = None
+
+            def execute(self, a, b):
+                self.exec_cnt += 1
+                self.params.append(b)
+                if self.exec_cnt == 1:
+                    return MockCursor
+
+            def commit(self):
+                self.has_commit = True
+
+            def close(self):
+                pass
+
+        mock.return_value = MockConn()
+        ret, code = furniture.rate_owner("mockfid", "realbuyer@gmail.com", 5)
+
+        self.assertEqual(ret, json.dumps({"error": ""}))
+        self.assertEqual(code, 200)
+        self.assertEqual(mock.return_value.exec_cnt, 3)
+        self.assertEqual(mock.return_value.params,
+                         [["mockfid"], [5, "owner@gmail.com"], ["mockfid"]])
+        self.assertEqual(mock.return_value.has_commit, True)
+
+    @patch('sqlite3.connect')
+    def test_rate_buyer_client_error(self, mock):
+        class MockCursor:
+            def __init__(self, rec):
+                self.rec = rec
+
+            def fetchone(self):
+                return self.rec
+
+        class MockConn:
+            def __init__(self, rec):
+                self.rec = rec
+                self.has_commit = False
+
+            def execute(self, a, b):
+                return MockCursor(self.rec)
+
+            def close(self):
+                pass
+
+        for fid, buyer_email, rating, dbrec, exp_msg in [
+            (
+                    "", "", 10000, None,
+                    "rating score should be in the range of [0, 5]"
+            ),
+            (
+                    "", "", -1, None,
+                    "rating score should be in the range of [0, 5]"
+            ),
+            (
+                    "mockfid", "111@gmail.com", 5, None,
+                    "fid not existed"
+            ),
+            (
+                    "mockfid", "111@gmail.com", 5,
+                    ("111@gmail.com", "", "pending"),
+                    "please rate after the transaction is completed"
+            ),
+            (
+                    "mockfid", "111@gmail.com", 5,
+                    ("222@gmail.com", "", "completed"),
+                    "rating can only be triggered by the buyer"
+            ),
+            (
+                    "mockfid", "111@gmail.com", 5,
+                    ("111@gmail.com", "", "rated"),
+                    "this transaction has been rated"
+            ),
+        ]:
+            mock.return_value = MockConn(dbrec)
+
+            ret, code = furniture.rate_owner(fid, buyer_email, rating)
+            ret = json.loads(ret)
+
+            self.assertEqual(code, 400)
+            self.assertEqual(ret["error"], exp_msg)
+            self.assertFalse(mock.return_value.has_commit)
+
+    @patch('sqlite3.connect')
+    def test_rate_buyer_sql_error(self, mock):
+        mock.side_effect = sqlite3.Error("mockerr")
+
+        ret, code = furniture.rate_owner("fid", "buyer", 5)
+
+        self.assertEqual(code, 500)
+        self.assertEqual(ret, json.dumps({"error": "db error: mockerr"}))


### PR DESCRIPTION
To implement this feature I modified some places:

1. a new field `buyer` is added in the furniture table
2. after rating, the status of the furniture will change from `completed` to `rated`
3. return the `buyer` field in the `search` interface

PTAL at whether these changes make sense to you. Thanks!


